### PR TITLE
bugfix: Set permissions for GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ on: # rebuild any PRs and main branch changes
 jobs:
   code-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: gvasilei/AutoReviewer@0.4
@@ -39,6 +42,9 @@ jobs:
   code-review:
     if: ${{ contains( github.event.label.name, 'AutoReview') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: gvasilei/AutoReviewer@0.4


### PR DESCRIPTION
Copy paste example return:

```
Run gvasilei/AutoReviewer@0.4
repoName: imager pull_number: 559 owner: kdosiodjinud sha: ad4[1](https://github.com/kdosiodjinud/imager/actions/runs/7770695067/job/21191172238#step:3:1)65ae[9](https://github.com/kdosiodjinud/imager/actions/runs/7770695067/job/21191172238#step:3:10)3a8abe211b7d5bc4873b2af96a511d3
(node:1639) ExperimentalWarning: Fetch is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Error: HttpError: Resource not accessible by integration
    at /home/runner/work/_actions/gvasilei/AutoReviewer/0.4/webpack:/typescript-action/node_modules/@octokit/request/dist-node/index.js:86:1
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
Error: Resource not accessible by integration
```
Setting these permissions fixes it :) 